### PR TITLE
메시지 전송 완료 후, 메시지 리스트 다시 불러오도록 변경

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,14 +2,16 @@ import React from 'react';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
 import { RoomBoard, RoomMaker } from './pages/rooms';
 import { ChatRoom } from './pages/chat';
+import { NoMatch } from './pages/error';
 
 function App() {
     return (
         <BrowserRouter>
-            <Route exact path="/" component={RoomBoard} />
             <Switch>
+                <Route exact path="/" component={RoomBoard} />
                 <Route exact path="/rooms" component={RoomMaker} />
                 <Route path="/rooms/:id" component={ChatRoom} />
+                <Route path="*" component={NoMatch} />
             </Switch>
         </BrowserRouter>
     );

--- a/src/components/atoms/Button.jsx
+++ b/src/components/atoms/Button.jsx
@@ -29,7 +29,7 @@ const flexStyles = css`
           flex: ${props.groupRatio};
           flex-basis: auto;
           margin: 0.1em;
-     `}
+      `}
 `;
 
 const colorStyles = css`
@@ -59,6 +59,18 @@ function setUpColorInfo(color) {
     if (color === 'orange') {
         return {
             backgroundColor: 'orange',
+            color: 'white'
+        };
+    }
+    if (color === 'green') {
+        return {
+            backgroundColor: '#81b214',
+            color: 'white'
+        };
+    }
+    if (color === 'blue') {
+        return {
+            backgroundColor: '#00bcd4',
             color: 'white'
         };
     }

--- a/src/components/atoms/Text.jsx
+++ b/src/components/atoms/Text.jsx
@@ -39,6 +39,15 @@ function setUpBoxModel(boxModel, attributes) {
             }
         );
     }
+    // Medium
+    if (boxModel === 'md') {
+        return Object.assign(
+            attributes, {
+                margin: '1em',
+                padding: '1em'
+            }
+        );
+    }
 
     // Standard
     return attributes;
@@ -65,12 +74,14 @@ function Text(props) {
 Text.propTypes = {
     text: PropTypes.string.isRequired,
     size: PropTypes.string,
-    boxModel: PropTypes.string
+    boxModel: PropTypes.string,
+    onClick: PropTypes.func
 };
 
 Text.defaultProps = {
     size: 'std',
-    boxModel: 'std'
+    boxModel: 'std',
+    onClick: () => { }
 };
 
 export default Text;

--- a/src/components/atoms/Text.stories.jsx
+++ b/src/components/atoms/Text.stories.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { action } from '@storybook/addon-actions';
 import Text from './Text';
 
 export default {
@@ -52,4 +53,12 @@ MediumSize.args = {
     text: 'MediumSize',
     size: 'md',
     boxModel: 'sm'
+};
+
+export const ClickAbleText = (args) => <Text {...args} />;
+ClickAbleText.args = {
+    text: 'ClickAbleText',
+    size: 'md',
+    boxModel: 'sm',
+    onClick: action('onClick')
 };

--- a/src/pages/chat/room/index.jsx
+++ b/src/pages/chat/room/index.jsx
@@ -46,10 +46,8 @@ function ChatRoom() {
     }, [fetch]);
 
     const onSend = async (message) => {
-        const responseMessage = await createMessages(id, message);
-        if (responseMessage) {
-            dispatch({ type: 'add', message: responseMessage });
-        }
+        await createMessages(id, message);
+        fetch();
     };
 
     return (

--- a/src/pages/error/index.js
+++ b/src/pages/error/index.js
@@ -1,0 +1,5 @@
+import NoMatch from './nomatch';
+
+export {
+    NoMatch
+};

--- a/src/pages/error/nomatch/index.jsx
+++ b/src/pages/error/nomatch/index.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import styled from 'styled-components';
+import Button from 'components/atoms/Button';
+import { useHistory } from 'react-router-dom';
+import Text from 'components/atoms/Text';
+
+const StyledNoMatch = styled.section`
+  margin: 10em;
+  padding: 2em;
+  border-radius: 12px;
+  background-color: white;
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+  height: 15em;
+`;
+
+function NoMatch() {
+    const history = useHistory();
+    const onGoHome = (event) => {
+        event.stopPropagation();
+        history.push('/');
+    };
+
+    const onGoBack = (event) => {
+        event.stopPropagation();
+        history.goBack();
+    };
+
+    const alertMessage = `'${history.location.pathname}' 경로에 대한 페이지가 존재하지 않습니다. 다시 한번 확인해주세요.`;
+    return (
+        <StyledNoMatch>
+            <Text text={alertMessage} size="md" boxModel="md" />
+            <Button text="메인 페이지로 가기" groupRatio={1} onClick={onGoHome} color="blue" />
+            <Button text="이전 페이지로 가기" groupRatio={1} onClick={onGoBack} color="green" />
+        </StyledNoMatch>
+    );
+}
+
+export default NoMatch;

--- a/src/pages/error/nomatch/index.stories.jsx
+++ b/src/pages/error/nomatch/index.stories.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import StoryRouter from 'storybook-react-router';
+import NoMatch from './index';
+
+export default {
+    title: 'pages/error/no-match/NoMatch',
+    component: NoMatch,
+    decorators: [StoryRouter()],
+    argTypes: {
+        history: {
+            type: { required: true },
+            description: 'react-router-dom 모듈의 history api',
+            table: {
+                type: { summary: 'object' }
+            },
+            control: {
+                type: 'object'
+            }
+        }
+    }
+};
+
+export const Standard = (args) => <NoMatch {...args} />;


### PR DESCRIPTION
## 🐣 변경 사항

- 메시지 전송 완료후, 메시지 리스트 리로딩하도록 변경 
  => 추후, 웹 소켓으로 변경한다면 기존 방식을 유지해야함

- 잘못된 경로로 접근한 경우 노출할 NoMatch 컴포넌트 추가 
  => `이전 페이지`, `메인 페이지` 로 이동할 수 있도록 버튼 구성

## 🏷 연관 이슈

> #33, #32 


## 🧢 체크 리스트

- [ ] 테스트 코드를 포함하고 있나요?
- [X] 공통된 코드 스타일을 따르 있나요?

## 🍄 ps
